### PR TITLE
Update _index.en.md

### DIFF
--- a/content/getting-started/_index.en.md
+++ b/content/getting-started/_index.en.md
@@ -10,9 +10,11 @@ pre = "<b>1. </b>"
 
 # Getting Started
 
-Find out how to getting started with Tang Primer board.
+Find out how to get started with Tang Primer board.
 
 1. [Requirements](/en/getting-started/requirements)
 2. [Installing Tang Dynasty IDE](/en/getting-started/installing-td-ide)
 3. [Installing USB Driver](/en/getting-started/installing-usb-driver)
 4. [Getting to Blinky](/en/getting-started/getting-to-blinky)
+
+Also see [Documentation and Support](/en/documentation-and-support)


### PR DESCRIPTION
I want to add a new chapter at the end which includes the URL to the Tang Primer documentation, chat group(s?), board schematics, English and Chinese Anlogic data sheets, RISC-V documentation, other example projects, Verilog and VHDL tutorials, etc.

Feel free to give it a different title than Documentation and Support.